### PR TITLE
Update TruncatedOracle.sol

### DIFF
--- a/contracts/libraries/TruncatedOracle.sol
+++ b/contracts/libraries/TruncatedOracle.sol
@@ -18,7 +18,7 @@ library TruncatedOracle {
     error TargetPredatesOldestObservation(uint32 oldestTimestamp, uint32 targetTimestamp);
 
     /// @notice This is the max amount of ticks in either direction that the pool is allowed to move at one time
-    int24 constant MAX_ABS_TICK_MOVE = 8100;
+    int24 constant MAX_ABS_TICK_MOVE = 9116;
 
     struct Observation {
         // the block timestamp of the observation


### PR DESCRIPTION
## Related Issue
8100 max tick movement is based on this oracle piece: https://blog.uniswap.org/uniswap-v3-oracles#fn-10

For k=30, tick movement should be 9116

## Description of changes
More of a reminder